### PR TITLE
Refactoring Tybalt Class - Adding BaseModel and Adage classes

### DIFF
--- a/tybalt/models.py
+++ b/tybalt/models.py
@@ -12,19 +12,71 @@ import tensorflow as tf
 from keras import backend as K
 from keras import optimizers
 from keras.utils import plot_model
-from keras.layers import Input, Dense, Lambda, Activation
+from keras.layers import Input, Dense, Lambda, Activation, Dropout
 from keras.layers.normalization import BatchNormalization
 from keras.models import Model, Sequential
+from keras.regularizers import l1
 
 from tybalt.utils.vae_utils import VariationalLayer, WarmUpCallback
 
 
-class Tybalt():
+class BaseModel():
+    def __init__(self):
+        pass
+
+    def get_summary(self):
+        self.full_model.summary()
+
+    def visualize_architecture(self, output_file):
+        # Visualize the connections of the custom VAE model
+        plot_model(self.full_model, to_file=output_file)
+
+    def visualize_training(self, output_file=None):
+        # Visualize training performance
+        history_df = pd.DataFrame(self.hist.history)
+        ax = history_df.plot()
+        ax.set_xlabel('Epochs')
+        ax.set_ylabel('Loss')
+        fig = ax.get_figure()
+        if output_file:
+            fig.savefig(output_file)
+        else:
+            fig.show()
+
+    def compress(self, df):
+        # Encode rnaseq into the hidden/latent representation - and save output
+        encoded_df = self.encoder(np.array(df))
+        encoded_df = pd.DataFrame(encoded_df,
+                                  columns=range(1, self.latent_dim + 1),
+                                  index=df.index)
+        return encoded_df
+
+    def get_decoder_weights(self):
+        # build a generator that can sample from the learned distribution
+        # can generate from any sampled z vector
+        weights = []
+        for layer in self.decoder.layers:
+            weights.append(layer.get_weights())
+        return(weights)
+
+    def predict(self, df):
+        return self.decoder.predict(np.array(df))
+
+    def save_models(self, encoder_file, decoder_file):
+        self.encoder.save(encoder_file)
+        self.decoder.save(decoder_file)
+
+
+class Tybalt(BaseModel):
     """
     Training and evaluation of a tybalt model
+
+    Usage: from tybalt.models import Tybalt
     """
-    def __init__(self, original_dim, latent_dim, batch_size, epochs,
-                 learning_rate, kappa, epsilon_std, beta):
+    def __init__(self, original_dim, latent_dim, batch_size=50, epochs=50,
+                 learning_rate=0.0005, kappa=1, epsilon_std=1.0,
+                 beta=K.variable(0)):
+        BaseModel.__init__(self)
         self.original_dim = original_dim
         self.latent_dim = latent_dim
         self.batch_size = batch_size
@@ -110,34 +162,19 @@ class Tybalt():
                                      original_dim=self.original_dim,
                                      beta=self.beta)(
                                 [self.rnaseq_input, self.rnaseq_reconstruct])
-        self.vae = Model(self.rnaseq_input, vae_layer)
-        self.vae.compile(optimizer=adam, loss=None, loss_weights=[self.beta])
-
-    def get_summary(self):
-        self.vae.summary()
-
-    def visualize_architecture(self, output_file):
-        # Visualize the connections of the custom VAE model
-        plot_model(self.vae, to_file=output_file)
+        self.full_model = Model(self.rnaseq_input, vae_layer)
+        self.full_model.compile(optimizer=adam, loss=None,
+                                loss_weights=[self.beta])
 
     def train_vae(self, train_df, test_df):
-        self.hist = self.vae.fit(np.array(train_df),
-                                 shuffle=True,
-                                 epochs=self.epochs,
-                                 batch_size=self.batch_size,
-                                 validation_data=(np.array(test_df),
-                                                  np.array(test_df)),
-                                 callbacks=[WarmUpCallback(self.beta,
-                                                           self.kappa)])
-
-    def visualize_training(self, output_file):
-        # Visualize training performance
-        history_df = pd.DataFrame(self.hist.history)
-        ax = history_df.plot()
-        ax.set_xlabel('Epochs')
-        ax.set_ylabel('VAE Loss')
-        fig = ax.get_figure()
-        fig.savefig(output_file)
+        self.hist = self.full_model.fit(np.array(train_df),
+                                        shuffle=True,
+                                        epochs=self.epochs,
+                                        batch_size=self.batch_size,
+                                        validation_data=(np.array(test_df),
+                                                         np.array(test_df)),
+                                        callbacks=[WarmUpCallback(self.beta,
+                                                                  self.kappa)])
 
     def connect_layers(self):
         # Make connections between layers to build separate encoder and decoder
@@ -155,17 +192,68 @@ class Tybalt():
                                   index=df.index)
         return encoded_df
 
-    def get_decoder_weights(self):
-        # build a generator that can sample from the learned distribution
-        # can generate from any sampled z vector
-        weights = []
-        for layer in self.decoder.layers:
-            weights.append(layer.get_weights())
-        return(weights)
 
-    def predict(self, df):
-        return self.decoder.predict(np.array(df))
+class Adage(BaseModel):
+    """
+    Training and evaluation of an ADAGE model
 
-    def save_models(self, encoder_file, decoder_file):
-        self.encoder.save(encoder_file)
-        self.decoder.save(decoder_file)
+    Usage: from tybalt.models import Adage
+    """
+    def __init__(self, original_dim, latent_dim, noise=0.05, batch_size=50,
+                 epochs=100, sparsity=0, learning_rate=1.1):
+        BaseModel.__init__(self)
+        self.original_dim = original_dim
+        self.latent_dim = latent_dim
+        self.noise = noise
+        self.batch_size = batch_size
+        self.epochs = epochs
+        self.sparsity = sparsity
+        self.learning_rate = learning_rate
+
+    def initialize_model(self):
+        """
+        Helper function to run that builds and compiles Keras layers
+        """
+        self.build_graph()
+        self.connect_layers()
+        self.compile_adage()
+
+    def build_graph(self):
+        # Build the Keras graph for an ADAGE model
+        self.input_rnaseq = Input(shape=(self.original_dim, ))
+        drop = Dropout(self.noise)(self.input_rnaseq)
+        self.encoded = Dense(self.latent_dim,
+                             activity_regularizer=l1(self.sparsity))(drop)
+        activation = Activation('relu')(self.encoded)
+        decoded_rnaseq = Dense(self.original_dim,
+                               activation='sigmoid')(activation)
+
+        self.full_model = Model(self.input_rnaseq, decoded_rnaseq)
+
+    def connect_layers(self):
+        # Separate out the encoder and decoder model
+        self.encoder = Model(self.input_rnaseq, self.encoded)
+
+        encoded_input = Input(shape=(self.latent_dim, ))
+        decoder_layer = self.full_model.layers[-1]
+        self.decoder = Model(encoded_input, decoder_layer(encoded_input))
+
+    def compile_adage(self):
+        # Compile the autoencoder to prepare for training
+        adadelta = optimizers.Adadelta(lr=self.learning_rate)
+        self.full_model.compile(optimizer=adadelta, loss='mse')
+
+    def train_adage(self, train_df, test_df):
+        self.hist = self.full_model.fit(np.array(train_df), np.array(train_df),
+                                        shuffle=True,
+                                        epochs=self.epochs,
+                                        batch_size=self.batch_size,
+                                        validation_data=(np.array(test_df),
+                                                         np.array(test_df)))
+
+    def compress(self, df):
+        # Encode rnaseq into the hidden/latent representation - and save output
+        encoded_df = self.encoder.predict(np.array(df))
+        encoded_df = pd.DataFrame(encoded_df, index=df.index,
+                                  columns=range(1, self.latent_dim + 1))
+        return encoded_df

--- a/tybalt/models.py
+++ b/tybalt/models.py
@@ -201,7 +201,8 @@ class Adage(BaseModel):
     Usage: from tybalt.models import Adage
     """
     def __init__(self, original_dim, latent_dim, noise=0.05, batch_size=50,
-                 epochs=100, sparsity=0, learning_rate=1.1):
+                 epochs=100, sparsity=0, learning_rate=1.1,
+                 loss='mse'):
         BaseModel.__init__(self)
         self.original_dim = original_dim
         self.latent_dim = latent_dim
@@ -210,6 +211,7 @@ class Adage(BaseModel):
         self.epochs = epochs
         self.sparsity = sparsity
         self.learning_rate = learning_rate
+        self.loss = loss
 
     def initialize_model(self):
         """
@@ -242,7 +244,7 @@ class Adage(BaseModel):
     def compile_adage(self):
         # Compile the autoencoder to prepare for training
         adadelta = optimizers.Adadelta(lr=self.learning_rate)
-        self.full_model.compile(optimizer=adadelta, loss='mse')
+        self.full_model.compile(optimizer=adadelta, loss=self.loss)
 
     def train_adage(self, train_df, test_df):
         self.hist = self.full_model.fit(np.array(train_df), np.array(train_df),


### PR DESCRIPTION
In adding the `Adage` class - many of the methods were redundant with the Tybalt methods. The `BaseModel` class stores these common methods and the pull request also updates `Tybalt` to inherit these methods.