### PR TITLE
Adding option to tie ADAGE weights together

### DIFF
--- a/tybalt/data_models.py
+++ b/tybalt/data_models.py
@@ -154,6 +154,11 @@ class DataModel():
         beta = K.variable(beta)
         loss = kwargs.pop('loss', 'binary_crossentropy')
         validation_ratio = kwargs.pop('validation_ratio', 0.1)
+        tied_weights = kwargs.pop('tied_weights', True)
+        if tied_weights and model == 'adage':
+            use_decoder_weights = False
+        else:
+            use_decoder_weights = True
         verbose = kwargs.pop('verbose', True)
         tybalt_separate_loss = kwargs.pop('separate_loss', False)
         adage_comp_loss = kwargs.pop('multiply_adage_loss', False)
@@ -198,7 +203,9 @@ class DataModel():
             self.tybalt_fit.train_vae(train_df=self.nn_train_df,
                                       test_df=self.nn_test_df,
                                       separate_loss=tybalt_separate_loss)
-            self.tybalt_decoder_w = self.tybalt_fit.get_decoder_weights()
+            self.tybalt_decoder_w = (
+                self.tybalt_fit.get_weights(decoder=use_decoder_weights)
+                )
 
             features = ['vae_{}'.format(x) for x in range(0, latent_dim)]
             self.tybalt_weights = pd.DataFrame(self.tybalt_decoder_w[1][0],
@@ -228,7 +235,9 @@ class DataModel():
                                         train_labels_df=self.nn_train_y,
                                         test_df=self.nn_test_df,
                                         test_labels_df=self.nn_test_y)
-            self.ctybalt_decoder_w = self.ctybalt_fit.get_decoder_weights()
+            self.ctybalt_decoder_w = (
+                self.ctybalt_fit.get_weights(decoder=use_decoder_weights)
+                )
 
             features = ['cvae_{}'.format(x) for x in range(0, latent_dim)]
             features_with_groups = features + ['group_{}'.format(x) for x in
@@ -261,17 +270,25 @@ class DataModel():
                                    learning_rate=learning_rate,
                                    loss=loss,
                                    verbose=verbose,
+                                   tied_weights=tied_weights,
                                    optimizer=adage_optimizer)
             self.adage_fit.initialize_model()
             self.adage_fit.train_adage(train_df=self.nn_train_df,
                                        test_df=self.nn_test_df,
                                        adage_comparable_loss=adage_comp_loss)
-            self.adage_decoder_w = self.adage_fit.get_decoder_weights()
+            self.adage_decoder_w = (
+                self.adage_fit.get_weights(decoder=use_decoder_weights)
+                )
 
             features = ['dae_{}'.format(x) for x in range(0, latent_dim)]
-            self.adage_weights = pd.DataFrame(self.adage_decoder_w[1][0],
-                                              columns=self.df.columns,
-                                              index=features)
+            if use_decoder_weights:
+                self.adage_weights = pd.DataFrame(self.adage_decoder_w[1][0],
+                                                  columns=self.df.columns,
+                                                  index=features)
+            else:
+                self.adage_weights = pd.DataFrame(self.adage_decoder_w[1][0],
+                                                  index=self.df.columns,
+                                                  columns=features).T
 
             self.adage_df = self.adage_fit.compress(self.df)
             self.adage_df.columns = features

--- a/tybalt/data_models.py
+++ b/tybalt/data_models.py
@@ -203,12 +203,12 @@ class DataModel():
             self.tybalt_fit.train_vae(train_df=self.nn_train_df,
                                       test_df=self.nn_test_df,
                                       separate_loss=tybalt_separate_loss)
-            self.tybalt_decoder_w = (
-                self.tybalt_fit.get_weights(decoder=use_decoder_weights)
-                )
 
             features = ['vae_{}'.format(x) for x in range(0, latent_dim)]
-            self.tybalt_weights = pd.DataFrame(self.tybalt_decoder_w[1][0],
+            self.tybalt_weights = (
+                self.tybalt_fit.get_weights(decoder=use_decoder_weights)
+                )
+            self.tybalt_weights = pd.DataFrame(self.tybalt_weights[1][0],
                                                columns=self.df.columns,
                                                index=features)
 
@@ -276,19 +276,14 @@ class DataModel():
             self.adage_fit.train_adage(train_df=self.nn_train_df,
                                        test_df=self.nn_test_df,
                                        adage_comparable_loss=adage_comp_loss)
-            self.adage_decoder_w = (
-                self.adage_fit.get_weights(decoder=use_decoder_weights)
-                )
 
             features = ['dae_{}'.format(x) for x in range(0, latent_dim)]
-            if use_decoder_weights:
-                self.adage_weights = pd.DataFrame(self.adage_decoder_w[1][0],
-                                                  columns=self.df.columns,
-                                                  index=features)
-            else:
-                self.adage_weights = pd.DataFrame(self.adage_decoder_w[1][0],
-                                                  index=self.df.columns,
-                                                  columns=features).T
+            self.adage_weights = (
+                self.adage_fit.get_weights(decoder=use_decoder_weights)
+                )
+            self.adage_weights = pd.DataFrame(self.adage_weights[1][0],
+                                              columns=self.df.columns,
+                                              index=features)
 
             self.adage_df = self.adage_fit.compress(self.df)
             self.adage_df.columns = features

--- a/tybalt/models.py
+++ b/tybalt/models.py
@@ -347,7 +347,7 @@ class Adage(BaseModel):
         self.decoder = Model(encoded_input, decoder_layer(encoded_input))
 
         if self.tied_weights:
-            # The keras graph is build differently for a tied weight model
+            # The keras graph is built differently for a tied weight model
             # Build a model with input and output Tensors of the encoded layer
             self.encoder = Model(self.encoded.input, self.encoded.output)
         else:

--- a/tybalt/models.py
+++ b/tybalt/models.py
@@ -2,7 +2,7 @@
 tybalt/models.py
 2017 Gregory Way
 
-Functions enabling the construction and usage of a Tybalt model
+Functions enabling the construction and usage of Tybalt and ADAGE models
 """
 
 import numpy as np
@@ -18,6 +18,7 @@ from keras.regularizers import l1
 
 from tybalt.utils.vae_utils import VariationalLayer, WarmUpCallback
 from tybalt.utils.vae_utils import LossCallback
+from tybalt.utils.adage_utils import TiedWeightsDecoder
 from tybalt.utils.base import VAE, BaseModel
 
 
@@ -287,8 +288,8 @@ class Adage(BaseModel):
     Usage: from tybalt.models import Adage
     """
     def __init__(self, original_dim, latent_dim, noise=0.05, batch_size=50,
-                 epochs=100, sparsity=0, learning_rate=0.0005,
-                 loss='mse', optimizer='adam', verbose=True):
+                 epochs=100, sparsity=0, learning_rate=0.0005, loss='mse',
+                 optimizer='adam', tied_weights=True, verbose=True):
         BaseModel.__init__(self)
         self.model_name = 'ADAGE'
         self.original_dim = original_dim
@@ -300,6 +301,7 @@ class Adage(BaseModel):
         self.learning_rate = learning_rate
         self.loss = loss
         self.optimizer = optimizer
+        self.tied_weights = tied_weights
         self.verbose = verbose
 
     def _build_graph(self):
@@ -314,6 +316,22 @@ class Adage(BaseModel):
 
         self.full_model = Model(self.input_rnaseq, decoded_rnaseq)
 
+    def _build_tied_weights_graph(self):
+        # Build Keras graph for an ADAGE model with tied weights
+        self.encoded = Dense(self.latent_dim,
+                             input_shape=(self.original_dim, ),
+                             activity_regularizer=l1(self.sparsity),
+                             activation='relu')
+        dropout_layer = Dropout(self.noise)
+        self.tied_decoder = TiedWeightsDecoder(input_shape=(self.latent_dim, ),
+                                               output_dim=self.original_dim,
+                                               activation='sigmoid',
+                                               encoder=self.encoded)
+        self.full_model = Sequential()
+        self.full_model.add(self.encoded)
+        self.full_model.add(dropout_layer)
+        self.full_model.add(self.tied_decoder)
+
     def _compile_adage(self):
         # Compile the autoencoder to prepare for training
         if self.optimizer == 'adadelta':
@@ -324,19 +342,25 @@ class Adage(BaseModel):
 
     def _connect_layers(self):
         # Separate out the encoder and decoder model
-        self.encoder = Model(self.input_rnaseq, self.encoded)
-
         encoded_input = Input(shape=(self.latent_dim, ))
         decoder_layer = self.full_model.layers[-1]
         self.decoder = Model(encoded_input, decoder_layer(encoded_input))
+
+        if self.tied_weights:
+            self.encoder = Model(self.encoded.input, self.encoded.output)
+        else:
+            self.encoder = Model(self.input_rnaseq, self.encoded)
 
     def initialize_model(self):
         """
         Helper function to run that builds and compiles Keras layers
         """
-        self._build_graph()
-        self._compile_adage()
+        if self.tied_weights:
+            self._build_tied_weights_graph()
+        else:
+            self._build_graph()
         self._connect_layers()
+        self._compile_adage()
 
     def train_adage(self, train_df, test_df, adage_comparable_loss=False):
         self.hist = self.full_model.fit(np.array(train_df), np.array(train_df),

--- a/tybalt/models.py
+++ b/tybalt/models.py
@@ -347,6 +347,8 @@ class Adage(BaseModel):
         self.decoder = Model(encoded_input, decoder_layer(encoded_input))
 
         if self.tied_weights:
+            # The keras graph is build differently for a tied weight model
+            # Build a model with input and output Tensors of the encoded layer
             self.encoder = Model(self.encoded.input, self.encoded.output)
         else:
             self.encoder = Model(self.input_rnaseq, self.encoded)

--- a/tybalt/utils/adage_utils.py
+++ b/tybalt/utils/adage_utils.py
@@ -1,0 +1,29 @@
+from keras import activations
+from keras import backend as K
+from keras.layers import Layer
+
+
+class TiedWeightsDecoder(Layer):
+    """
+    Transpose the encoder weights to apply decoding of compressed latent space
+    """
+    def __init__(self, output_dim, encoder, activation=None, **kwargs):
+        self.output_dim = output_dim
+        self.encoder = encoder
+        self.activation = activations.get(activation)
+        super(TiedWeightsDecoder, self).__init__(**kwargs)
+
+    def build(self, input_shape):
+        self.kernel = self.encoder.weights
+        super(TiedWeightsDecoder, self).build(input_shape)
+
+    def call(self, x):
+        # Encoder weights: [weight_matrix, bias_term]
+        output = K.dot(x - self.encoder.weights[1],
+                       K.transpose(self.encoder.weights[0]))
+        if self.activation is not None:
+            output = self.activation(output)
+        return output
+
+    def compute_output_shape(self, input_shape):
+        return (input_shape[0], self.output_dim)

--- a/tybalt/utils/base.py
+++ b/tybalt/utils/base.py
@@ -36,12 +36,16 @@ class BaseModel():
         else:
             fig.show()
 
-    def get_decoder_weights(self):
+    def get_weights(self, decoder=True):
         # build a generator that can sample from the learned distribution
         # can generate from any sampled z vector
         weights = []
-        for layer in self.decoder.layers:
-            weights.append(layer.get_weights())
+        if decoder:
+            for layer in self.decoder.layers:
+                weights.append(layer.get_weights())
+        else:
+            for layer in self.encoder.layers:
+                weights.append(layer.get_weights())
         return weights
 
     def save_models(self, encoder_file, decoder_file):

--- a/tybalt/utils/base.py
+++ b/tybalt/utils/base.py
@@ -44,7 +44,10 @@ class BaseModel():
                 weights.append(layer.get_weights())
         else:
             for layer in self.encoder.layers:
-                weights.append(layer.get_weights())
+                # Encoder weights must be transposed
+                encoder_weights = layer.get_weights()
+                encoder_weights = [np.transpose(x) for x in encoder_weights]
+                weights.append(encoder_weights)
         return weights
 
     def save_models(self, encoder_file, decoder_file):

--- a/tybalt/utils/base.py
+++ b/tybalt/utils/base.py
@@ -37,8 +37,7 @@ class BaseModel():
             fig.show()
 
     def get_weights(self, decoder=True):
-        # build a generator that can sample from the learned distribution
-        # can generate from any sampled z vector
+        # Extract weight matrices from encoder or decoder
         weights = []
         if decoder:
             for layer in self.decoder.layers:


### PR DESCRIPTION
The [original ADAGE](https://github.com/greenelab/adage) used tied weights (and was written in Theano). The previous ADAGE version in this repo did not have a tied weights constraint (meaning that the encoder and decoder weights were free to vary independently). We observed relatively poor performance of ADAGE models compared to other compression techniques (see [simulation_results.md](https://github.com/greenelab/tybalt/blob/69d00e804eaab873c57c0a803e269e50eb46d878/simulation_results.md) and [z_dimensions_hyperparameter_sweep_results.md](https://github.com/greenelab/tybalt/blob/master/z_dimensions_hyperparameter_sweep_results.md)). We hypothesized that one of the reasons could be because of the lack of ADAGE tied weights.

There used to be an option to tie weights in the Keras autoencoder class (keras-team/keras#180, keras-team/keras#3261) but this has [since been removed](https://github.com/keras-team/keras/commit/94c930e99e8908d2188213672bed050b54ebdb5a).

The pull request adds this functionality as a custom layer and also modifies the `DataModel` class to use these options.

