### PR TITLE
add setup.py file for tybalt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+setup(name='tybalt',
+      description='train autoencoders with gene expression data',
+      long_description='compress gene expression data with unsupervised learning to extract biological patterns',
+      author='Gregory Way',
+      author_email='gregory.way@gmail.com',
+      url='https://github.com/greenelab/tybalt',
+      packages=['tybalt'],
+      license='BSD 3-Clause License',
+      install_requires=['keras', 'tensorflow', 'pandas', 'scikit-learn'])
+

--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,7 @@ setup(name='tybalt',
       url='https://github.com/greenelab/tybalt',
       packages=['tybalt'],
       license='BSD 3-Clause License',
-      install_requires=['keras', 'tensorflow', 'pandas', 'scikit-learn'])
+      install_requires=['keras', 'tensorflow', 'pandas', 'scikit-learn'],
+      python_requires='>=3.4')
+
 


### PR DESCRIPTION
Adding `setup.py` file to enable other repositories to use methods in the `tybalt` folder. Inspired by greenelab/hetmech#89